### PR TITLE
Dev kishimon

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -47,11 +47,22 @@
         width: 67.5vw;
         height: 3em;
     }
+
+    .crifums {
+        position: relative;
+        text-align: center;
+    }
     
     .crifum {
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
+        -webkit-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
         color: #00BE96;
         font-size: 1.5rem;
         font-weight: 800;
+        margin-bottom: 16xp;
     }
     
     .graph {

--- a/static/index.css
+++ b/static/index.css
@@ -7,9 +7,16 @@
     }
     
     .twitter-timeline {
+        width: 13vw;
+        height: 90vh;
         right: 0;
         top: 0;
         float: right;
+    }
+
+    iframe {
+        width: 13vw !important;
+        height: 90vh !important;
     }
     
     h1 {

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
     <link rel="stylesheet" href="/static/index.css">
     <a class="twitter-timeline" data-width="13vw" data-height="90vh" data-theme="dark" href="https://twitter.com/log_analyzer_cf?ref_src=twsrc%5Etfw">Tweets by log_analyzer_cf</a>
+    <script>
+      //twitter-timeline の data-height を制御する部分
+      var windoewHeight = document.getElementsByClassName('twitter-timeline')[0];
+      windoewHeight.attributes[2].nodeValue = Math.ceil(window.innerHeight * 0.9)
+    </script>
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     <center>
         <h1>ココフォリア Log Analyzer [CoC]</h1>
@@ -49,11 +54,8 @@
         </div>
         </center>
         <a href="https://github.com/kitsystemyou/ccf-log-analyzer" target="_blank">Github Repository</a>
-        <script>
-            //twitter-timeline の data-height を制御する部分
-            var windoewHeight = document.getElementsByClassName('twitter-timeline')[0];
-            windoewHeight.attributes[2].nodeValue = Math.ceil(window.innerHeight * 0.9)
 
+        <script>
             var ctx = document.getElementById("myBarChart");
             Chart.defaults.global.defaultFontColor = 'black';
             Chart.plugins.register({

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,13 +40,20 @@
 
         <hr size="5">
         <div class="graph">
-        <canvas id="myBarChart"></canvas>
-        <a class = "crifum">クリティカル✨ <span style="color:red; font-size:2rem"> {{ cf["critical_percent"] }}% </span></a>
-        <a class = "crifum">ファンブル💀 <span style="color:#fe0084; font-size:2rem"> {{ cf["fumble_percent"] }}% </span></a><br>
-        <a class = "crifum">トータル📊 <span style="color:black; font-size:2rem"> {{ cf["total"] }}回 </span></a>
+          <canvas id="myBarChart"></canvas>
+        </div>
+        <div class="crifums">
+          <a class = "crifum">クリティカル✨ <span style="color:red; font-size:2rem"> {{ cf["critical_percent"] }}% </span></a><br><br>
+          <a class = "crifum">ファンブル💀 <span style="color:#fe0084; font-size:2rem"> {{ cf["fumble_percent"] }}% </span></a><br><br>
+          <a class = "crifum">トータル📊 <span style="color:black; font-size:2rem"> {{ cf["total"] }}回 </span></a>
+        </div>
         </center>
         <a href="https://github.com/kitsystemyou/ccf-log-analyzer" target="_blank">Github Repository</a>
         <script>
+            //twitter-timeline の data-height を制御する部分
+            var windoewHeight = document.getElementsByClassName('twitter-timeline')[0];
+            windoewHeight.attributes[2].nodeValue = Math.ceil(window.innerHeight * 0.9)
+
             var ctx = document.getElementById("myBarChart");
             Chart.defaults.global.defaultFontColor = 'black';
             Chart.plugins.register({
@@ -109,7 +116,6 @@
                 }
             });
         </script>
-        </div>
 </body>
 
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,7 @@
 <body>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
     <link rel="stylesheet" href="/static/index.css">
-    <a class="twitter-timeline" data-width="13vw" data-height="25vw" data-theme="dark" href="https://twitter.com/log_analyzer_cf?ref_src=twsrc%5Etfw">Tweets by log_analyzer_cf</a>
+    <a class="twitter-timeline" data-width="13vw" data-height="90vh" data-theme="dark" href="https://twitter.com/log_analyzer_cf?ref_src=twsrc%5Etfw">Tweets by log_analyzer_cf</a>
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     <center>
         <h1>ココフォリア Log Analyzer [CoC]</h1>
@@ -41,7 +41,7 @@
         <hr size="5">
         <div class="graph">
         <canvas id="myBarChart"></canvas>
-        <a class = "crifum">クリティカル✨ <span style="color:red; font-size:2rem"> {{ cf["critical_percent"] }}% 　</span></a>
+        <a class = "crifum">クリティカル✨ <span style="color:red; font-size:2rem"> {{ cf["critical_percent"] }}% </span></a>
         <a class = "crifum">ファンブル💀 <span style="color:#fe0084; font-size:2rem"> {{ cf["fumble_percent"] }}% </span></a><br>
         <a class = "crifum">トータル📊 <span style="color:black; font-size:2rem"> {{ cf["total"] }}回 </span></a>
         </center>

--- a/templates/users.html
+++ b/templates/users.html
@@ -19,6 +19,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
     <link rel="stylesheet" href="/static/index.css">
     <a class="twitter-timeline" data-width="13vw" data-height="90vh" data-theme="dark" href="https://twitter.com/log_analyzer_cf?ref_src=twsrc%5Etfw">Tweets by log_analyzer_cf</a>
+    <script>
+      //twitter-timeline の data-height を制御する部分
+      var windoewHeight = document.getElementsByClassName('twitter-timeline')[0];
+      windoewHeight.attributes[2].nodeValue = Math.ceil(window.innerHeight * 0.9)
+    </script>
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     <center>
         <h1>ココフォリア Log Analyzer [CoC](Beta)</h1>
@@ -43,10 +48,6 @@
     </center>
         <a href="https://github.com/kitsystemyou/ccf-log-analyzer" target="_blank">Github Repository</a>
         <script>
-            //twitter-timeline の data-height を制御する部分
-            var windoewHeight = document.getElementsByClassName('twitter-timeline')[0];
-            windoewHeight.attributes[2].nodeValue = Math.ceil(window.innerHeight * 0.9)
-            
             {% for i in data["result"] %}
             var username = '{{i["name"]}}';
             var hist_data = {{i["hist_data"]}};

--- a/templates/users.html
+++ b/templates/users.html
@@ -18,7 +18,7 @@
 <body>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
     <link rel="stylesheet" href="/static/index.css">
-    <a class="twitter-timeline" data-width="13vw" data-height="25vw" data-theme="dark" href="https://twitter.com/log_analyzer_cf?ref_src=twsrc%5Etfw">Tweets by log_analyzer_cf</a>
+    <a class="twitter-timeline" data-width="13vw" data-height="90vh" data-theme="dark" href="https://twitter.com/log_analyzer_cf?ref_src=twsrc%5Etfw">Tweets by log_analyzer_cf</a>
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     <center>
         <h1>ココフォリア Log Analyzer [CoC](Beta)</h1>
@@ -43,6 +43,10 @@
     </center>
         <a href="https://github.com/kitsystemyou/ccf-log-analyzer" target="_blank">Github Repository</a>
         <script>
+            //twitter-timeline の data-height を制御する部分
+            var windoewHeight = document.getElementsByClassName('twitter-timeline')[0];
+            windoewHeight.attributes[2].nodeValue = Math.ceil(window.innerHeight * 0.9)
+            
             {% for i in data["result"] %}
             var username = '{{i["name"]}}';
             var hist_data = {{i["hist_data"]}};


### PR DESCRIPTION
- やったことリスト
  - twitter-timeline をいい感じの長さに修正
  - crifum が twitter-timeline の影響を受けなくなったよ
  - `</div>` の位置がおかしくて center が分割されてたので位置調整をして center が分割しなくなったよ

![スクリーンショット 2022-08-27 150054](https://user-images.githubusercontent.com/24647571/187017602-8ebd077f-2c27-4bd0-b24c-fa7a9d2615c8.png)
![スクリーンショット 2022-08-27 150141](https://user-images.githubusercontent.com/24647571/187017605-a82d7c65-7333-4b63-b6c2-081556c956c7.png)
